### PR TITLE
Github CI workflow for lint/test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Lint and test
+
+on: pull_request
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        # Tests need access to system packages (for dbus-python)
+        os: [
+            "ubuntu-24.04", # Python 3.12
+          ]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: make .venv
+      - name: Run lint
+        run: make lint
+      - name: Run tests
+        run: make test


### PR DESCRIPTION
This is not using the `setup-python` action but relies on the Python
version shipped by the operating system.
   
The tests require `dbus-python` which is provided in the correct
version by the system package `python3-dbus`. Installing it via pip
requires additional development dependencies (dbus dev packages).
