### PR TITLE
Observer: Add support for BLE active scanning

### DIFF
--- a/src/pb_ble/bluezdbus/observer.py
+++ b/src/pb_ble/bluezdbus/observer.py
@@ -5,15 +5,15 @@ This module contains a Pybricks-specific implementation of the BLE "Observer" ro
 import logging
 from contextlib import AbstractAsyncContextManager
 from struct import pack
-from typing import NamedTuple, Sequence
+from typing import Literal, NamedTuple, Sequence
 
 from bleak import AdvertisementData, BleakScanner, BLEDevice
 from bleak.assigned_numbers import AdvertisementDataType
 from bleak.backends.bluezdbus.advertisement_monitor import OrPattern
-from bleak.backends.bluezdbus.scanner import BlueZScannerArgs
+from bleak.backends.bluezdbus.scanner import BlueZDiscoveryFilters, BlueZScannerArgs
 from cachetools import TTLCache
 
-from ..constants import LEGO_CID, PybricksBroadcastData
+from ..constants import LEGO_CID, PYBRICKS_MAX_CHANNEL, PybricksBroadcastData
 from ..messages import decode_message
 
 log = logging.getLogger(name=__name__)
@@ -37,16 +37,28 @@ class BlueZPybricksObserver(AbstractAsyncContextManager):
 
     def __init__(
         self,
+        scanning_mode: Literal["active", "passive"] = "passive",
         channels: Sequence[int] | None = None,
         rssi_threshold: int | None = None,
+        device_pattern: str | None = "Pybricks",
         message_ttl: int = 60,
     ):
         self.channels = channels or []
         self.rssi_threshold = rssi_threshold
+        self.device_pattern = device_pattern
         self.advertisements: TTLCache = TTLCache(
-            maxsize=len(self.channels) or 255, ttl=message_ttl
+            maxsize=len(self.channels) or PYBRICKS_MAX_CHANNEL, ttl=message_ttl
         )
 
+        # Filters used for active scanning
+        filters: BlueZDiscoveryFilters = BlueZDiscoveryFilters()
+
+        if device_pattern:
+            filters["Pattern"] = device_pattern
+        if rssi_threshold:
+            filters["RSSI"] = rssi_threshold
+
+        # Patterns used for passive scanning
         or_patterns: list[OrPattern | tuple[int, AdvertisementDataType, bytes]]
 
         if self.channels:
@@ -67,22 +79,50 @@ class BlueZPybricksObserver(AbstractAsyncContextManager):
                 )
             ]
 
+        log.debug(
+            "Observer init: scanning_mode=%s, device_pattern=%s, rssi_threshold=%i",
+            scanning_mode,
+            device_pattern,
+            rssi_threshold,
+        )
+
         self.scanner = BleakScanner(
             detection_callback=self.callback,
-            scanning_mode="passive",
+            scanning_mode=scanning_mode,
             bluez=BlueZScannerArgs(
+                filters=filters,
                 or_patterns=or_patterns,
             ),
         )
 
     def callback(self, device: BLEDevice, ad: AdvertisementData):
         if self.rssi_threshold is not None and ad.rssi < self.rssi_threshold:
-            log.debug("Filtered AD due to RSSI threshold: %i", self.rssi_threshold)
+            log.debug("Filtered AD due to RSSI below threshold: %i", ad.rssi)
+            return
+
+        if (ad.local_name and self.device_pattern) and not ad.local_name.startswith(
+            self.device_pattern
+        ):
+            log.debug("Filtered AD due to invalid device name: %s", ad.local_name)
+            return
+
+        if LEGO_CID not in ad.manufacturer_data:
+            log.debug(
+                "Filtered AD due to invalid manufacturer data: %s",
+                ad.manufacturer_data.keys(),
+            )
             return
 
         message = ad.manufacturer_data[LEGO_CID]
         channel, data = decode_message(message)
-        log.info("Pybricks broadcast on channel %i: %s", channel, data)
+
+        if self.channels and channel not in self.channels:
+            log.debug("Filtered broadcast due to wrong channel: %i", channel)
+            return
+
+        log.info(
+            "Pybricks broadcast on channel %i: %s (rssi %s)", channel, data, ad.rssi
+        )
         self.advertisements[channel] = ObservedAdvertisement(data, ad.rssi)
 
     def observe(self, channel: int) -> ObservedAdvertisement | None:

--- a/src/pb_ble/cli/observe.py
+++ b/src/pb_ble/cli/observe.py
@@ -5,7 +5,7 @@ CLI interface to listen for Pybricks BLE broadcasts.
 import argparse
 import asyncio
 import logging
-from typing import Sequence
+from typing import Literal, Sequence
 
 from pb_ble.bluezdbus import BlueZPybricksObserver
 
@@ -30,6 +30,13 @@ parser.add_argument(
     help="RSSI threshold",
 )
 parser.add_argument(
+    "--mode",
+    required=False,
+    choices=["active", "passive"],
+    default="passive",
+    help="BLE scanning mode",
+)
+parser.add_argument(
     "--debug",
     required=False,
     action="store_true",
@@ -37,9 +44,15 @@ parser.add_argument(
 )
 
 
-async def observe(channels: Sequence[int], rssi_threshold: int):
+async def observe(
+    scanning_mode: Literal["active", "passive"],
+    channels: Sequence[int],
+    rssi_threshold: int,
+):
     stop_event = asyncio.Event()
-    async with BlueZPybricksObserver(channels, rssi_threshold):
+    async with BlueZPybricksObserver(
+        scanning_mode=scanning_mode, channels=channels, rssi_threshold=rssi_threshold
+    ):
         await stop_event.wait()
 
 
@@ -52,6 +65,7 @@ def main():
     try:
         asyncio.run(
             observe(
+                scanning_mode=args.mode,
                 channels=args.channels,
                 rssi_threshold=args.rssi,
             )

--- a/src/pb_ble/constants.py
+++ b/src/pb_ble/constants.py
@@ -3,6 +3,9 @@ from typing import NamedTuple
 LEGO_CID = 0x0397
 """LEGO System A/S company identifier."""
 
+PYBRICKS_MAX_CHANNEL = 255  # uint8
+"""Highest channel supported by Pybricks broadcast/observe messages"""
+
 # Type aliases
 PybricksBroadcastValue = bool | int | float | str | bytes
 """ Type of a value that can be broadcast."""

--- a/tests/test_observer.py
+++ b/tests/test_observer.py
@@ -6,25 +6,56 @@ from pb_ble.bluezdbus import (
 )
 
 
-@pytest_asyncio.fixture(autouse=True)
-async def require_passive_scan(adapter_details, adapter_name):
-    if not adapter_details["passive_scan"]:
-        pytest.skip(
-            reason=f"Bluetooth adapter '{adapter_name}' does not support BLE passive scanning"
-        )
+class TestPassiveBlueZObserver:
+    @pytest_asyncio.fixture(autouse=True)
+    async def require_passive_scan(sef, adapter_details, adapter_name):
+        if not adapter_details["passive_scan"]:
+            pytest.skip(
+                reason=f"Bluetooth adapter '{adapter_name}' does not support BLE passive scanning"
+            )
 
+    @pytest_asyncio.fixture()
+    async def observer(self):
+        async with BlueZPybricksObserver(scanning_mode="passive") as observer:
+            yield observer
 
-@pytest_asyncio.fixture()
-async def observer():
-    async with BlueZPybricksObserver() as observer:
-        yield observer
-
-
-class TestBlueZObserver:
     def test_create_observer(self, message_bus):
-        observer = BlueZPybricksObserver([0])
+        observer = BlueZPybricksObserver(
+            scanning_mode="passive", channels=[0], rssi_threshold=-100
+        )
         assert observer is not None
+        assert observer.channels == [0]
+        assert observer.rssi_threshold == -100
+        assert observer.device_pattern == "Pybricks"
 
-    def test_observe(self, adapter, observer):
+    async def test_observe(self, adapter, observer):
+        # WHEN a channel is observed
         data = observer.observe(0)
+
+        # THEN there should be no data
+        assert data is None
+
+
+class TestActiveBlueZObserver:
+    @pytest_asyncio.fixture()
+    async def observer(self):
+        async with BlueZPybricksObserver(scanning_mode="active") as observer:
+            yield observer
+
+    async def test_create_observer(self, message_bus, adapter):
+        observer = BlueZPybricksObserver(
+            scanning_mode="active",
+            channels=[0],
+            device_pattern="Name",
+        )
+        assert observer is not None
+        assert observer.channels == [0]
+        assert observer.rssi_threshold is None
+        assert observer.device_pattern == "Name"
+
+    async def test_observe(self, adapter, observer):
+        # WHEN a channel is observed
+        data = observer.observe(0)
+
+        # THEN there should be no data
         assert data is None

--- a/tests/test_vhub.py
+++ b/tests/test_vhub.py
@@ -18,14 +18,16 @@ class TestVirtualBLE:
         assert ble is not None
 
     async def test_observe(self):
-        ble = await get_virtual_ble(1, [2])
+        ble = await get_virtual_ble(broadcast_channel=1, observe_channels=[2])
         data = ble.observe(2)
         assert data is None
 
     async def test_broadcast(self):
-        ble = await get_virtual_ble(1, [2])
+        ble = await get_virtual_ble(broadcast_channel=1, observe_channels=[2])
         await ble.broadcast(42)
 
     async def test_context(self):
-        async with await get_virtual_ble(1, [2]) as ble:
+        async with await get_virtual_ble(
+            broadcast_channel=1, observe_channels=[2]
+        ) as ble:
             assert ble.version() is not None

--- a/tools/pybricks_virtual_ble.py
+++ b/tools/pybricks_virtual_ble.py
@@ -1,3 +1,7 @@
+"""
+An example showing a "Virtual Hub BLE radio" operating in Python.
+"""
+
 import asyncio
 import random
 
@@ -19,7 +23,7 @@ async def observe(vble: _common.BLE, observe_channel: int, interval: float = 1.0
             print(f"Observation: '{data}' [{rssi} dBm]")
 
 
-async def broadcast(vble, interval: float = 10.0):
+async def broadcast(vble: _common.BLE, interval: float = 10.0):
     """
     Coroutine that broadcasts a new random number
     on the given interval.
@@ -31,19 +35,22 @@ async def broadcast(vble, interval: float = 10.0):
 
 
 async def main():
-    broadcast_channel = 1
+    # observe config
+    scanning_mode = "passive"
     observe_channel = 0
 
-    tasks = set()
+    # broadcast config
+    broadcast_channel = 1
 
-    async with await get_virtual_ble(broadcast_channel, [observe_channel]) as vble:
+    async with await get_virtual_ble(
+        broadcast_channel=broadcast_channel,
+        observe_channels=[observe_channel],
+        scanning_mode=scanning_mode,
+    ) as vble:
         observe_task = asyncio.create_task(observe(vble, observe_channel))
         broadcast_task = asyncio.create_task(broadcast(vble))
 
-        tasks.add(observe_task)
-        tasks.add(broadcast_task)
-
-        await asyncio.gather(*tasks)
+        await asyncio.gather(observe_task, broadcast_task)
 
 
 asyncio.run(main())


### PR DESCRIPTION
Add support for active scanning as fallback.

While passive scanning is preferred, it's not always working reliably for me. I tested on two different systems, of which one works fine, and the other doesn't:

* ✅ Ubuntu 22.04, Linux Kernel 6.5, BlueZ 5.64  
  Works as expected.
* ❌ Debian Bookworm, Linux Kernel 6.7, BlueZ 5.66  
  Only receives first advertisement (but not subsequent updates for manufacturer data changes): 

There are some bug reports in various places upstream (in bleak, bluez and kernel-bluetooth) about only the first advertisement being received correctly when only the manufacturer data changes between advertisements. As far as I can tell these should all be resolved in the above versions though. Maybe some hardware quirk?